### PR TITLE
Docs: Update xmerl user guide URL

### DIFF
--- a/lib/xmerl_c14n.ex
+++ b/lib/xmerl_c14n.ex
@@ -7,7 +7,7 @@ defmodule XmerlC14n do
   [http://www.w3.org/TR/xml-c14n](http://www.w3.org/TR/xml-c14n)
 
   These routines work on `xmerl` data structures (see the [xmerl user
-  guide](http://erlang.org/doc/apps/xmerl/users_guide.html) for details).
+  guide](https://www.erlang.org/doc/apps/xmerl/xmerl_ug.html) for details).
   """
 
   ### TYPE DECLARATIONS


### PR DESCRIPTION
💁 Unfortunately the previous URL no longer redirects or resolves to the current xmerl documentation. This change updates the URL.